### PR TITLE
Improve Docker PHP performance by opcache and cached mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./portal-files/Dockerfile
       context: .
     volumes:
-      - ./portal:/portal
+      - ./portal:/portal:cached
       - ./portal-files/vhost.conf:/etc/apache2/sites-enabled/000-default.conf
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
   elasticsearch:

--- a/portal-files/Dockerfile
+++ b/portal-files/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update -y \
 	libcurl4-openssl-dev \
 	pkg-config \
 	zlib1g-dev \
-	jq
+	jq \
+	libpcre3-dev
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -20,7 +21,14 @@ RUN docker-php-ext-install \
 	curl \
 	pdo \
 	mbstring \
-	zip
+	zip \
+	opcache
+
+RUN docker-php-ext-enable \
+	opcache
+
+# Add opcache configuration
+ADD portal-files/php-opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 
 RUN a2enmod rewrite
 

--- a/portal-files/php-opcache.ini
+++ b/portal-files/php-opcache.ini
@@ -1,0 +1,7 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=10000
+opcache.memory_consumption=128
+opcache.save_comments=1
+opcache.revalidate_freq=1


### PR DESCRIPTION
Docker on macOS (and probably on Windows) has bad performance on IO tasks, so Laravel requests are slow. These improvement makes huge increase on performance. 