### PR TITLE
fix breadcrumbtemplate in template in preview

### DIFF
--- a/portal/resources/views/common/breadcrumb.blade.php
+++ b/portal/resources/views/common/breadcrumb.blade.php
@@ -14,19 +14,12 @@
                 @endif
             @endforeach
         @endif
+        <li class="breadcrumb-item active" aria-current="page">
         @if($folder['node']['fields']['startpage']['path'] != ($node['node']['path'] ?? ""))
-            <li class="breadcrumb-item">
-                <a href="{{ $folder['node']['path'] ?? "#" }}">
-                    {{ $folder['node']['fields']['name'] ?? "" }}
-                </a>
-            </li>
-            <li class="breadcrumb-item active" aria-current="page">
-                {{ $node['fields']['name'] ?? "" }}
-            </li>
+            {{ $node['fields']['name'] ?? "" }}
         @else
-            <li class="breadcrumb-item active" aria-current="page">
-                {{ $folder['node']['fields']['name'] ?? "" }}
-            </li>
+            {{ $folder['node']['fields']['name'] ?? "" }}
         @endif
+        </li>
     </ol>
 </nav>

--- a/portal/resources/views/common/breadcrumb.blade.php
+++ b/portal/resources/views/common/breadcrumb.blade.php
@@ -5,7 +5,7 @@
         </li>
         @if(isset($node['breadcrumb']))
             @foreach (array_reverse($node['breadcrumb']) as $breadcrumb)
-                @if(@isset($breadcrumb['node']['fields']['startpage']['path']) && $node['node']['path'] != $breadcrumb['node']['fields']['startpage']['path'] && !$loop->last)
+                @if(@isset($breadcrumb['node']['fields']['startpage']['path']) && @isset($node['node']['path']) && $node['node']['path'] != $breadcrumb['node']['fields']['startpage']['path'] && !$loop->last)
                     <li class="breadcrumb-item">
                         <a href="{{ $breadcrumb['node']['fields']['startpage']['path'] }}">
                             {{ $breadcrumb['node']['fields']['name'] }}


### PR DESCRIPTION
in cms preview we only get the folder data - therefor the node property is not available.
$node['node'] was a call to an undefined index in this case.
This additional check keeps the template from throwing error 500