### PR TITLE
SUP-7360: make sure everyone agrees that mesh writes to /mesh/data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     image: gentics/mesh:0.27.2
     volumes:
       - mesh-config:/config
-      - mesh-data:/data
+      - mesh-data:/mesh/data
       - ./mesh/mesh.yml:/config/mesh.yml
       - ./mesh/keycloak_mapper.js:/config/keycloak_mapper.js
     ulimits:
@@ -41,6 +41,7 @@ services:
       MESH_ELASTICSEARCH_URL: "http://elasticsearch:9200"
       MESH_ELASTICSEARCH_START_EMBEDDED: "false"
       MESH_UPDATECHECK: "false"
+      MESH_GRAPH_DB_DIRECTORY: /mesh/data/graphdb
       JAVA_TOOL_OPTIONS: "-Xms320m -Xmx320m -XX:MaxDirectMemorySize=200m"
     # TODO: Remove this workaround when Mesh can handle Keycloak wait/timeout
     command: ["sh", "-c", "c=0;rc=-1; until [ \"$$rc\" = \"0\" ]; do wget -O/dev/null -T 3 keycloak:8080/auth/realms/reference/ 2>/dev/null; rc=$$?; if [ \"$$rc\" != \"0\" ]; then let 'c++'; echo 'Waiting for Keycloak #'$$c'...'; sleep 5; fi; done; exec java -jar mesh.jar"]


### PR DESCRIPTION
- mesh.yml uses relative paths, e.g. "data". the WORKDIR is /mesh -> writes to /mesh/data
- mesh uses $MESH_GRAPH_DB_DIRECTORY -> writes to /graphql
- docker-compose.yaml mounts a persistent volume under /data

Because of this mess, after a docker-compose down && docker-compose up, the mesh database is empty and the portal shows strange errors. This pull requests makes sure everyone writes to /mesh/data.